### PR TITLE
Display playback progress in activity sheet

### DIFF
--- a/lib/features/activity/presentation/widgets/activity_bottom_sheet.dart
+++ b/lib/features/activity/presentation/widgets/activity_bottom_sheet.dart
@@ -31,6 +31,7 @@ import 'progress_bar.dart';
 import 'terminate_stream_dialog.dart';
 import 'time_eta.dart';
 import 'time_total.dart';
+import 'progress_percent.dart';
 
 class ActivityBottomSheet extends StatefulWidget {
   final ServerModel server;
@@ -261,9 +262,17 @@ class _ActivityBottomSheetState extends State<ActivityBottomSheet> {
                                                             server: widget.server,
                                                             activity: activity,
                                                           ),
-                                                          TimeTotal(
-                                                            viewOffset: activity.viewOffset!,
-                                                            duration: activity.duration!,
+                                                          Row(
+                                                            children: [
+                                                              if (activity.progressPercent != null) ...[
+                                                                ProgressPercent(progressPercent: activity.progressPercent!),
+                                                                const Text(' • '),
+                                                              ],
+                                                              TimeTotal(
+                                                                viewOffset: activity.viewOffset!,
+                                                                duration: activity.duration!,
+                                                              ),
+                                                            ],
                                                           ),
                                                         ],
                                                       ),

--- a/lib/features/activity/presentation/widgets/progress_percent.dart
+++ b/lib/features/activity/presentation/widgets/progress_percent.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class ProgressPercent extends StatelessWidget {
+  final int progressPercent;
+
+  const ProgressPercent({
+    super.key,
+    required this.progressPercent,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      '$progressPercent%',
+      style: const TextStyle(
+        fontSize: 13,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Description

This PR adds support for displaying the playback percentage in the activity bottom sheet. For now I have put it to the left of the elapsed/total time with a bullet to separate, but I am open to other suggestions.

Fixes Tautulli/Tautulli-Remote#191

| ![image](https://github.com/user-attachments/assets/081862e4-e9d1-4fc8-b2ec-1fb3f76f585b) |
| - |

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
